### PR TITLE
[Feat] 날씨, 일정, 운세에 따른 옷차림 추천 기능 구현

### DIFF
--- a/src/main/java/UMC_Hackathon/DailyMate/converter/RecommendConverter.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/converter/RecommendConverter.java
@@ -1,0 +1,15 @@
+package UMC_Hackathon.DailyMate.converter;
+
+import UMC_Hackathon.DailyMate.domain.Schedules;
+import UMC_Hackathon.DailyMate.web.dto.RecommendResponseDTO;
+import UMC_Hackathon.DailyMate.web.dto.ScheduleResponseDTO;
+
+public class RecommendConverter {
+    public static RecommendResponseDTO.RecommendResultDTO toRecommendResultDTO (String messageFortunePoint, String messageDateName, String recommend){
+        return RecommendResponseDTO.RecommendResultDTO.builder()
+                .fortunePoint(messageFortunePoint)
+                .fortuneDate(messageDateName)
+                .recommend(recommend)
+                .build();
+    }
+}

--- a/src/main/java/UMC_Hackathon/DailyMate/domain/Schedules.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/domain/Schedules.java
@@ -7,6 +7,7 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -22,8 +23,7 @@ public class Schedules extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long Id;
 
-    @Size(min = 10, max = 10, message = "날짜는 정확히 10자리로 입력해야 합니다. 예: YYYY.MM.DD")
-    private String date;
+    private LocalDate date;
 
     @Column(nullable = false, length = 50)
     private String title;

--- a/src/main/java/UMC_Hackathon/DailyMate/domain/Users.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/domain/Users.java
@@ -10,6 +10,7 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -41,7 +42,7 @@ public class Users extends BaseEntity {
     @Column(columnDefinition = "VARCHAR(10)")
     private Gender gender;
 
-    private Date birthday;
+    private LocalDate birthday;
 
     @Enumerated(EnumType.STRING)
     @Column

--- a/src/main/java/UMC_Hackathon/DailyMate/repository/ScheduleRepository.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/repository/ScheduleRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
@@ -15,4 +16,6 @@ public interface ScheduleRepository extends JpaRepository<Schedules, Long> {
 
     @Query("SELECT s FROM Schedules s where s.users = :user")
     List<Schedules> getSchedulesByUser(Users user);
+
+    List<Schedules> findByUsersAndDate(Users user, LocalDate date);
 }

--- a/src/main/java/UMC_Hackathon/DailyMate/repository/WeatherRepository.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/repository/WeatherRepository.java
@@ -1,9 +1,13 @@
 package UMC_Hackathon.DailyMate.repository;
 
+import UMC_Hackathon.DailyMate.domain.Schedules;
+import UMC_Hackathon.DailyMate.domain.Users;
 import UMC_Hackathon.DailyMate.domain.Weather;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 public interface WeatherRepository extends JpaRepository<Weather, Long> {
-
+    Weather findByUsers(Users users);
 }

--- a/src/main/java/UMC_Hackathon/DailyMate/service/FortuneService/RecommendCommandServiceImpl.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/service/FortuneService/RecommendCommandServiceImpl.java
@@ -1,9 +1,15 @@
 package UMC_Hackathon.DailyMate.service.FortuneService;
 
 import UMC_Hackathon.DailyMate.converter.FortuneConverter;
+import UMC_Hackathon.DailyMate.converter.RecommendConverter;
+import UMC_Hackathon.DailyMate.domain.Fortune;
+import UMC_Hackathon.DailyMate.domain.Schedules;
 import UMC_Hackathon.DailyMate.domain.Users;
+import UMC_Hackathon.DailyMate.domain.Weather;
 import UMC_Hackathon.DailyMate.repository.FortuneRepository;
+import UMC_Hackathon.DailyMate.repository.ScheduleRepository;
 import UMC_Hackathon.DailyMate.repository.UserRepository;
+import UMC_Hackathon.DailyMate.repository.WeatherRepository;
 import UMC_Hackathon.DailyMate.web.dto.Chatgpt.ChatGPTRequestDTO;
 import UMC_Hackathon.DailyMate.web.dto.Chatgpt.ChatGPTResponseDTO;
 import UMC_Hackathon.DailyMate.web.dto.RecommendRequestDTO;
@@ -15,6 +21,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -22,6 +33,8 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
 
     private final UserRepository userRepository;
     private final FortuneRepository fortuneRepository;
+    private final WeatherRepository weatherRepository;
+    private final ScheduleRepository scheduleRepository;
 
     @Value("${openai.model}")
     private String model;
@@ -108,6 +121,36 @@ public class RecommendCommandServiceImpl implements RecommendCommandService {
 
         fortuneRepository.save(FortuneConverter.toFortune(user, messageDateName, point, messageFortune, messageColor1, messageColor2, messageItem1, messageItem2));
 
-        return null;
+        // 날씨 정보 가져오기
+        Weather weather = weatherRepository.findByUsers(user);
+        String temperature = weather.getTemperature().toString();
+        String weatherCondition = weather.getWeatherCondition().toString();
+
+        // 해당 날짜의 일정 모두 가져오기
+        List<Schedules> schedulesList = scheduleRepository.findByUsersAndDate(user, LocalDate.now());
+        List<String> titles = schedulesList.stream()
+                .map(Schedules::getTitle) // getTitle() 호출
+                .collect(Collectors.toList());
+
+        // 운세정보 가져오기 - ChatGPT로 가져온 값 사용.
+
+        // ChagGPT로 옷차림 추천받기
+        String color1 = messageColor1.split(" - ")[0];
+        String color2 = messageColor1.split(" - ")[0];
+        String item1 = messageColor1.split(" - ")[0];
+        String item2 = messageColor1.split(" - ")[0];
+        systemPrompt = "";
+        userPrompt = "아래의 날씨 정보와 일정 그리고 운세정보(행운의 색과 아이템)에 따라 카테고리별로 입을만한 옷을 추천해줘\n"
+                + "날씨 정보 - 기온: 섭씨" + temperature + ", 날씨: " + weatherCondition + "\n"
+                + "일정 정보 : " + titles + "\n"
+                + "행운의 색 : " + color1 + ", " + color2 + " 행운의 아이템: " + item1 + ", " + item2 + "\n"
+                + "옷 카테고리 : Outer, Top, Bottom, ACC"
+                + "답변 예시는 아래와 같아\n"
+                + "Outer : 롱 패딩\nTop : 흰색 맨투맨\nBottom : 조거 팬츠\nACC : 목도리, 장갑, 실버링\n\n"
+                + "답변 예시와 같은 형식 이외의 말은 제외시키고 답해줘 그리고 답변예시의 형식과 정확히 동일하게 답해줘";
+        String recommend = getResponseOfChatGptApi(systemPrompt, userPrompt);
+        System.out.println(recommend);
+
+        return RecommendConverter.toRecommendResultDTO(messageFortunePoint, messageDateName, recommend);
     }
 }

--- a/src/main/java/UMC_Hackathon/DailyMate/web/controller/RecommendController.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/web/controller/RecommendController.java
@@ -18,7 +18,7 @@ public class RecommendController {
     private final RecommendCommandService recommendCommandService;
 
     @Operation(summary = "자세한 운세 생성 및 옷차림 추천 api", description =
-            "# 자세한 운세를 생성하고 저장하며 회원정보와 운세, 그리고 날씨 정보에 따른 옷차림을 ChagGpt로 추천해줍니다."
+            "# 자세한 운세를 생성하고 저장하며 회원정보와 운세, 그리고 날씨 정보에 따른 옷차림을 ChatGpt로 추천해줍니다."
     )
     @PostMapping("/")
     public ApiResponse<RecommendResponseDTO.RecommendResultDTO> CreandRecommendAndPostFortune(

--- a/src/main/java/UMC_Hackathon/DailyMate/web/dto/RecommendResponseDTO.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/web/dto/RecommendResponseDTO.java
@@ -11,12 +11,8 @@ public class RecommendResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RecommendResultDTO {
-        Long userId;
-        String outer;
-        String top;
-        String bottom;
-        String acc;
         String fortunePoint;
         String fortuneDate;
+        String recommend;
     }
 }

--- a/src/main/java/UMC_Hackathon/DailyMate/web/dto/ScheduleRequestDTO.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/web/dto/ScheduleRequestDTO.java
@@ -5,11 +5,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDate;
+
 public class ScheduleRequestDTO {
     @Getter
     public static class ScheduleDto {
         @NotNull
-        String date;
+        LocalDate date;
         @NotBlank
         String title;
         @NotBlank
@@ -20,7 +22,7 @@ public class ScheduleRequestDTO {
     @Setter
     public static class ScheduleUpdateRequestDto {
         @NotNull
-        String date;
+        LocalDate date;
         @NotBlank
         String title;
         @NotBlank

--- a/src/main/java/UMC_Hackathon/DailyMate/web/dto/ScheduleResponseDTO.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/web/dto/ScheduleResponseDTO.java
@@ -34,7 +34,7 @@ public class ScheduleResponseDTO {
     @AllArgsConstructor
     public static class SchedulePreViewDto {
         Long scheduleId;
-        String date;
+        LocalDate date;
         String title;
         String content;
         LocalDate createdAt;

--- a/src/main/java/UMC_Hackathon/DailyMate/web/dto/UserRequestDTO.java
+++ b/src/main/java/UMC_Hackathon/DailyMate/web/dto/UserRequestDTO.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.time.LocalDate;
+
 public class UserRequestDTO {
     @Getter
     public static class JoinDto{
@@ -15,7 +17,7 @@ public class UserRequestDTO {
         @NotBlank
         String password;
         @NotNull
-        String birthday; // LocalDate로 선언..?
+        LocalDate birthday; // LocalDate로 선언..?
 
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #35

## 📝작업 내용
> 날씨, 일정, 운세에 따른 옷차림 추천 기능 구현

## 🔎코드 설명
> ChatGPT를 이용한 날씨, 일정, 운세에 따른 옷차림 추천 기능 구현

## 💬고민사항 및 리뷰 요구사항 (Optional)
> x

## 비고 (Optional)
> x
